### PR TITLE
add rust toolchain without using bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "extract-my-file"
+version = "0.1.0"
+authors = ["David Werner <david.werner@blue-yonder.com>","Markus Klein <markus-klein@live.de>"]
+edition = "2018"
+
+[lib]
+# Use both cdylib and rlib as targets
+# cdylib so we can than continue to convert it into webassembly using wasm-bindgen
+# rlib so we can make use of advanced native tooling during development
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.47"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# extract-my-file
+# Extract my file
+
 A website using wasm to extract your file on your local machine
+
+## Prerequesites for building the site
+
+This site uses Web Assembly (wasm) which is compiled from Rust code. So to work on it some toolchains are required:
+
+* The Rust toolchain to build our rust code and manange native dependencies. You can [install Rust from here][1].
+* `wasm-pack` is mostly a convinience which contains and invokes some other tools (mainly the Rust compiler and `wasm-bindgen`) for us in order to generate Web assembly and Java Script bindings. You can [install wasm-pack from here][2].
+
+## Building the site
+
+With the prerequesites installed, it should be as simple as:
+
+```bash
+wasm-pack build --target web
+```
+
+Since this web application is designed as a simple static website you should be able to just look at it with a local browser.
+
+By using the `--target web` flag we loose out on the ability of the default target to easily use npm packages from within Rust code, but we also no longer require a bundler.
+
+[1]: https://rustup.rs/
+[2]: https://rustwasm.github.io/wasm-pack/installer/

--- a/script.js
+++ b/script.js
@@ -1,3 +1,12 @@
+// Use ES module import syntax to import functionality from the module
+// that we have compiled.
+//
+// Note that the `default` import is an initialization function which
+// will "boot" the module and make it ready to use. Currently browsers
+// don't support natively imported WebAssembly as an ES module, but
+// eventually the manual initialization won't be required!
+import init, { extractingIsSupported } from './pkg/extract_my_file.js';
+
 let member = {
     inputEl: null,
     dropEl: null,
@@ -7,13 +16,18 @@ let member = {
 (function main() {
     member = {...initElements()}
     checkFileApiSupport()
+    initWasm();
 })()
+
+async function initWasm() {
+    await init();
+}
 
 function initElements() {
     const containerEl = document.createElement('div');
     containerEl.innerHTML =
         `<input type="file"/><br>
-            <div class="drop-zone">Drop input file here</div> 
+            <div class="drop-zone">Drop input file here</div>
             <output></output>`;
 
     const inputEl = containerEl.querySelector('input'),
@@ -59,5 +73,7 @@ function handleFileSelect(event) {
 }
 
 function showFileInfo(file) {
-    member.infoEl.innerText = `Name: ${file.name} Size: ${file.size} bytes`;
+    const extension = file.name.substr((file.name.lastIndexOf('.') + 1));
+    const is_supported = extractingIsSupported(extension);
+    member.infoEl.innerText = `Name: ${file.name} Size: ${file.size} bytes Supported: ${is_supported}`;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = extractingIsSupported)]
+/// Returns true if we support extracting files of the given type
+pub fn extracting_is_supported(_extension: &str) -> bool {
+    false
+}


### PR DESCRIPTION
This adds the Rust/wasm toolchain. It opens a rather obnoxious alert right then opening the side which obviously will have to go, yet I left it in for now, so you can check quickly if everything works by just opening the site.

I opted not to use a bundler for now. The main drawback seems to be, that without it we cannot import npm modules from within Rust, which we currently do not plan anyway.

I am unsure there the best point is to wait for `init` future which signalizes that the wasm code has been streamed successfully. Optimally we would stream the code during the time the user needs to select a file, so it is likely ready to go then the file is selected. Yet up until that point we should not block on it, so the site loads as fast as possible.

You probably need to install a few things before you can build this site again. Luckily the runtime requirements of the site are still low (i.e. we do not need a server). I added a prerequisites and a build section to the Readme in order to aid you with the transition.

Looking forward to your feedback!