### PR TITLE
Process file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.47"
+libflate = "0.1.25"

--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ function createHandleFileLoaded(file) {
     return function handleFileLoaded(event) {
         const buffer = event.target.result;
         const extension = file.name.substr((file.name.lastIndexOf('.') + 1));
-        const src = Source.new(extension, new Uint8Array(buffer));
+        const src = new Source(extension, new Uint8Array(buffer));
         showFileInfo(file, src);
     }
 }
@@ -93,7 +93,7 @@ function createHandleFileLoaded(file) {
 function showFileInfo(file, src) {
     const size = src.size();
     const isSupported = src.extractingIsSupported();
-    const extSize = src.extract();
+    const extSize = src.extract().length;
     member.infoEl.innerText = `Name: ${file.name}, Size: ${size} bytes, Supported: ${isSupported}, Extracted size: ${extSize}`;
 }
 

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@
 // will "boot" the module and make it ready to use. Currently browsers
 // don't support natively imported WebAssembly as an ES module, but
 // eventually the manual initialization won't be required!
-import init, {extractingIsSupported} from './pkg/extract_my_file.js';
+import init, { Source } from './pkg/extract_my_file.js';
 
 let member = {
     inputEl: null,
@@ -14,7 +14,7 @@ let member = {
 };
 
 (function main() {
-    member = {...initElements()};
+    member = { ...initElements() };
     checkFileApiSupport();
     initWasm();
 })();
@@ -64,16 +64,36 @@ function handleDrop(event) {
     event.preventDefault();
 
     const file = event.dataTransfer.files[0];
-    showFileInfo(file);
+    processFile(file);
 }
 
 function handleFileSelect(event) {
     const file = event.target.files[0];
-    showFileInfo(file);
+    processFile(file);
 }
 
-function showFileInfo(file) {
-    const extension = file.name.substr((file.name.lastIndexOf('.') + 1)),
-        isSupported = extractingIsSupported(extension);
-    member.infoEl.innerText = `Name: ${file.name}, Size: ${file.size} bytes, Supported: ${isSupported}`;
+function processFile(file) {
+    // `file` is supposed to be a blob which offers a possibility to wait for an `ArrayBuffer`. Yet,
+    // until we get this to work, let's just use a `FileReader` instead.
+    const reader = new FileReader();
+    reader.onloadend = createHandleFileLoaded(file);
+    reader.readAsArrayBuffer(file);
 }
+
+// Binds `file` to `handleFileLoaded`.
+function createHandleFileLoaded(file) {
+    return function handleFileLoaded(event) {
+        const buffer = event.target.result;
+        const extension = file.name.substr((file.name.lastIndexOf('.') + 1));
+        const src = Source.new(extension, new Uint8Array(buffer));
+        showFileInfo(file, src);
+    }
+}
+
+function showFileInfo(file, src) {
+    const size = src.size();
+    const isSupported = src.extractingIsSupported();
+    const extSize = src.extract();
+    member.infoEl.innerText = `Name: ${file.name}, Size: ${size} bytes, Supported: ${isSupported}, Extracted size: ${extSize}`;
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,56 @@
 use wasm_bindgen::prelude::*;
+use libflate::gzip;
+use std::io::{self, Read};
 
-#[wasm_bindgen(js_name = extractingIsSupported)]
-/// Returns true if we support extracting files of the given type
-pub fn extracting_is_supported(_extension: &str) -> bool {
-    false
+/// Source archive the user has selected.
+#[wasm_bindgen]
+pub struct Source {
+    buffer: Vec<u8>,
+    decoder: Decoder,
+}
+
+#[wasm_bindgen]
+impl Source {
+    pub fn new(extension: &str, buffer: Vec<u8>) -> Source {
+        let decoder = if extension == "gz" {
+            Decoder::Gzip
+        } else {
+            Decoder::Unsupported
+        };
+        Source {
+            decoder, 
+            buffer
+        }
+    }
+
+    #[wasm_bindgen(js_name = extractingIsSupported)]
+    pub fn extracting_is_supported(&self) -> bool {
+        match self.decoder {
+            Decoder::Unsupported => false,
+            _ => true,
+        }
+    }
+
+    pub fn size(&self) -> usize{
+        self.buffer.len()
+    }
+
+    pub fn extract(&self) -> usize {
+        match self.decoder {
+            Decoder::Gzip => {
+                ungz(&self.buffer).unwrap_or(0)
+            },
+            Decoder::Unsupported => 0,
+        }
+    }
+}
+
+enum Decoder {
+    Gzip,
+    Unsupported,
+}
+
+fn ungz(bytes: &[u8]) -> io::Result<usize> {
+    let decoder = gzip::Decoder::new(bytes)?;
+    Ok(decoder.bytes().count())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-use wasm_bindgen::prelude::*;
+
 use libflate::gzip;
 use std::io;
-
+use wasm_bindgen::prelude::*;
 /// Source archive the user has selected.
 #[wasm_bindgen]
 pub struct Source {
@@ -18,10 +18,7 @@ impl Source {
         } else {
             Decoder::Unsupported
         };
-        Source {
-            decoder, 
-            buffer
-        }
+        Source { decoder, buffer }
     }
 
     #[wasm_bindgen(js_name = extractingIsSupported)]
@@ -32,15 +29,13 @@ impl Source {
         }
     }
 
-    pub fn size(&self) -> usize{
+    pub fn size(&self) -> usize {
         self.buffer.len()
     }
 
     pub fn extract(&self) -> Vec<u8> {
         match self.decoder {
-            Decoder::Gzip => {
-                ungz(&self.buffer).unwrap_or_else(|_| Vec::new())
-            },
+            Decoder::Gzip => ungz(&self.buffer).unwrap_or_else(|_| Vec::new()),
             Decoder::Unsupported => Vec::new(),
         }
     }


### PR DESCRIPTION
I am not happy with the interface, or the overall design. Maybe creating a `Source` object is over-engineering right now. BUT: This branch does actually extract a `.gz` file in Rust and passes it as `Uint8Array` back to JavaScript!

Sorry for the formatting changes in JavaScript. We need to sync the formatting of our IDEs. This branch is more for discussing than merging anyway.