### PR TITLE
Smaller binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = true
 
 [features]
 # If you uncomment this line, it will enable `wee_alloc`:
-#default = ["wee_alloc"]
+default = ["wee_alloc"]
 
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ js-sys = "0.3.32"
 # like the DOM.
 [dependencies.web-sys]
 version = "0.3.32"
-features = ["console", "File", "Blob"]
+features = ["File", "Blob"]
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use web_sys::console;
 
 mod decoder;
 mod encoder;
@@ -22,9 +21,6 @@ pub fn main_js() -> Result<(), JsValue> {
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
-
-    // Your code goes here!
-    console::log_1(&JsValue::from_str("Hello world!"));
 
     Ok(())
 }


### PR DESCRIPTION
A smaller binary by:

* Excluding the web_sys `console` feature which has only been used to log "Hello, World!"
* Using `wee alloc` instead of the standard allocator (We don't do many heap allocations, so this should be fine).